### PR TITLE
Add pattern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fauxmo-jellyfish
 A [fauxmo](https://github.com/n8henrie/fauxmo) plugin to control [JellyFish Lighting](https://www.jellyfishlighting.com/).
 
-Enables Amazon Echo (Alexa) control (**on/off** and pattern for one or more zones) of JellyFish Lighting via an emulated Belkin WeMo switch and the JellyFish controller websocket.
+Enables Amazon Echo (Alexa) control (on/off state and pattern for one or more zones) of JellyFish Lighting via an emulated Belkin WeMo switch and the JellyFish controller websocket.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fauxmo-jellyfish
 A [fauxmo](https://github.com/n8henrie/fauxmo) plugin to control [JellyFish Lighting](https://www.jellyfishlighting.com/).
 
-Enables Amazon Echo (Alexa) control (**on** and **off** for one or more zones) of JellyFish Lighting via an emulated Belkin WeMo switch and the JellyFish controller websocket.
+Enables Amazon Echo (Alexa) control (**on/off** and pattern for one or more zones) of JellyFish Lighting via an emulated Belkin WeMo switch and the JellyFish controller websocket.
 
 ## Usage
 
@@ -10,7 +10,7 @@ Tested on a Raspberry Pi 4 Model B and JellyFish controller version 020108. Sett
 1. Install Python: `sudo apt-get update && sudo apt-get install python3 python3-pip`
 2. Install Python dependencies: `pip3 install fauxmo websocket-client`
 3. Clone this repo: `git clone https://github.com/Synse/fauxmo-jellyfish.git && cd fauxmo-jellyfish`
-4. Update `config.json` with the plugin `path`, your JellyFish `controller_ip`, and JellyFish `zones`
+4. Update `config.json` with the plugin `path`, your JellyFish `controller_ip`, `pattern` (optional), and `zones`
 5. Start fauxmo: `fauxmo -c config.json`
 6. Say **Alexa discover devices** and wait for discovery to finish
 

--- a/config.json
+++ b/config.json
@@ -10,7 +10,8 @@
                     "port": 12300,
                     "name": "JellyFish Lights",
                     "controller_ip": "192.168.3.1",
-                    "zones": ["All Lights"]
+                    "zones": ["All Lights"],
+                    "pattern": "Colors/Blue"
                 }
             ]
         }

--- a/jellyfishplugin.py
+++ b/jellyfishplugin.py
@@ -28,6 +28,7 @@ Example config:
                     "port": 12301,
                     "name": "Garage Lights",
                     "controller_ip": "192.168.3.1",
+                    "pattern": "Holidays/Valentines Day",
                     "zones": ["Front", "Back"]
                 }
             ]
@@ -53,6 +54,7 @@ class JellyFishPlugin(FauxmoPlugin):
         port: int,
         name: str,
         controller_ip: str = "192.168.3.1",
+        pattern: str = "",
         zones: Sequence[str],
     ) -> None:
         """Initialize an JellyFishPlugin instance.
@@ -62,10 +64,12 @@ class JellyFishPlugin(FauxmoPlugin):
             port: Port for Fauxmo to make this device available to Amazon Echo
 
             controller_ip: IP address of the JellyFish controller
+            pattern: The pattern file to use (default is the current pattern)
             zones: The zone name(s) to turn on/off
         """
         print('JellyFishPlugin intialized for device "%s"' % name)
         self.controller_ip = controller_ip
+        self.pattern = pattern
         self.zones = '","'.join(zones)
 
         super().__init__(name=name, port=port)
@@ -76,8 +80,8 @@ class JellyFishPlugin(FauxmoPlugin):
         Returns:
             True if device seems to have been turned on.
         """
-        print('Turning on "%s" for zones ["%s"]' % (self.name, self.zones))
-        cmd = '{"cmd":"toCtlrSet","runPattern":{"file":"","data":"","id":"","state":1,"zoneName":["%s"]}}' % self.zones
+        print('Turning on "%s" with pattern "%s" for zones ["%s"]' % (self.name, self.pattern, self.zones))
+        cmd = '{"cmd":"toCtlrSet","runPattern":{"file":"%s","data":"","id":"","state":1,"zoneName":["%s"]}}' % (self.pattern, self.zones)
 
         try:
             print('  send >> %s' % cmd)
@@ -98,8 +102,8 @@ class JellyFishPlugin(FauxmoPlugin):
         Returns:
             True if device seems to have been turned off.
         """
-        print('Turning off "%s" for zones ["%s"]' % (self.name, self.zones))
-        cmd = '{"cmd":"toCtlrSet","runPattern":{"file":"","data":"","id":"","state":0,"zoneName":["%s"]}}' % self.zones
+        print('Turning off "%s" with pattern "%s" for zones ["%s"]' % (self.name, self.pattern, self.zones))
+        cmd = '{"cmd":"toCtlrSet","runPattern":{"file":"%s","data":"","id":"","state":0,"zoneName":["%s"]}}' % (self.pattern, self.zones)
 
         try:
             print('  send >> %s' % cmd)


### PR DESCRIPTION
This PR adds an optional device configuration for `pattern` (the file/pattern name). This allows users to create multiple devices that can be used to change patterns via Alexa.

**Example configuration:**

```json
{
    "FAUXMO": {
        "ip_address": "auto"
    },
    "PLUGINS": {
        "JellyFishPlugin": {
            "path": "~/fauxmo-jellyfish/jellyfishplugin.py",
            "DEVICES": [
                {
                    "port": 12300,
                    "name": "JellyFish Lights",
                    "controller_ip": "192.168.3.1",
                    "zones": ["All Lights"]
                },
                {
                    "port": 12301,
                    "name": "Christmas Subtle Lights",
                    "controller_ip": "192.168.3.1",
                    "pattern": "Christmas/Red Green White (Subtle)",
                    "zones": ["All Lights"]
                },
                {
                    "port": 12302,
                    "name": "Christmas Winter Lights",
                    "controller_ip": "192.168.3.1",
                    "pattern": "Christmas/Winter",
                    "zones": ["All Lights"]
                }
            ]
        }
    }
}
```

With the configuration above:
- "Alexa turn [on|off] JellyFish Lights" will toggle the lights on/off with the current pattern
- "Alexa turn on Christmas Subtle Lights" will turn on and set the `Christmas/Red Green White (Subtle)` pattern
- "Alexa turn on Christmas Winter Lights" will turn on and set the `Christmas/Winter` pattern

The "Christmas Subtle" and "Christmas Winter" devices can also be used to turn off the lights. This will set the pattern for the next time lights are turned on with no configured pattern.

Closes #2 