### PR TITLE
Make zones optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Enables Amazon Echo (Alexa) control (on/off state and pattern for one or more zo
 
 ## Usage
 
-Tested on a Raspberry Pi 4 Model B and JellyFish controller version 020108. Setting a static IP for your JellyFish controller and Raspberry Pi is strongly recommended.
+Tested on a Raspberry Pi 4 Model B, JellyFish controller version 020108, and fauxmo v0.5.2. Setting a static IP for your JellyFish controller and Raspberry Pi is strongly recommended.
 
 1. Install Python: `sudo apt-get update && sudo apt-get install python3 python3-pip`
 2. Install Python dependencies: `pip3 install fauxmo websocket-client`
 3. Clone this repo: `git clone https://github.com/Synse/fauxmo-jellyfish.git && cd fauxmo-jellyfish`
-4. Update `config.json` with the plugin `path`, your JellyFish `controller_ip`, `pattern` (optional), and `zones`
+4. Update `config.json` with the plugin `path`, your JellyFish `controller_ip`, `pattern` (optional, default is current pattern), and `zones` (optional, default is all zones)
 5. Start fauxmo: `fauxmo -c config.json`
 6. Say **Alexa discover devices** and wait for discovery to finish
 

--- a/jellyfishplugin.py
+++ b/jellyfishplugin.py
@@ -65,8 +65,8 @@ class JellyFishPlugin(FauxmoPlugin):
             port: Port for Fauxmo to make this device available to Amazon Echo
 
             controller_ip: IP address of the JellyFish controller
-            pattern: The pattern file to use (default is the current pattern)
-            zones: The zone name(s) to turn on/off (default is all zones)
+            pattern: The pattern file to use (optional, default is the current pattern)
+            zones: The zone name(s) to turn on/off (optional, default is all zones)
         """
         print('JellyFishPlugin intialized for device "%s"' % name)
         self.controller_ip = controller_ip


### PR DESCRIPTION
Makes the `zones` configuration optional. If no zones are specified the first `on()` / `off()` call will get all zones from the controller and update the configuration.

**Note:** If a user adds or renames a zone after using the device once they'll need to restart fauxmo to pick up the new zone.

Closes #4 